### PR TITLE
- Removed invalid "base" attribute from Element

### DIFF
--- a/Laurentius-libs/Laurentius-wsdl/src/main/resources/wsdl/messages/InMailListRequest.xsd
+++ b/Laurentius-libs/Laurentius-wsdl/src/main/resources/wsdl/messages/InMailListRequest.xsd
@@ -74,7 +74,7 @@ Copyright 2015, Supreme Court Republic of Slovenia
                                 <xs:documentation>Če je podatek "vnesen", servis vrača vse pošiljke z datumom sprejema manjšim  od vnesenega datuma </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="status" use="optional" base="xs:token" default="RECEIVED" >
+                        <xs:attribute name="status" use="optional" default="RECEIVED" >
                             <xs:annotation>
                                 <xs:documentation>Status pošiljke. Če status ni podan  je prevzeti status za pošiljke za 'RECEIVED'  
                                 </xs:documentation>


### PR DESCRIPTION
The "base" attribute is invalid inside the xs:attribute element and causes errors when generating Client libraries